### PR TITLE
fix #1; Disable jar task to avoid building plain archive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,6 @@ test {
     useJUnitPlatform()
 }
 
-bootJar {
-    mainClassName('com.mstar.paymentgateway.PaymentGatewayApplication')
-    manifest {
-        attributes 'Start-Class': 'com.mstar.paymentgateway.PaymentGatewayApplication'
-    }
+jar {
+    enabled = false
 }


### PR DESCRIPTION
### Solution to issue #2 
Build processes of the commits (PR #1 , PR #3 , PR #4 ) produce 2 jar files under the `build` directory:

-> `projectname-version.jar` produced by `bootJar` Gradle task. (_executable jar_)

_Reference: [Spring Boot (2.5.0) Gradle Plugin Reference - 4.1. Packaging Executable Jars](https://docs.spring.io/spring-boot/docs/2.5.0/gradle-plugin/reference/htmlsingle/#packaging-executable.jars)_:
> Executable jars can be built using the bootJar task. The task is automatically created when the java plugin is applied and is an instance of BootJar. The assemble task is automatically configured to depend upon the bootJar task so running assemble (or build) will also run the bootJar task.

<br/>

-> `projectname-version-plain.jar` produced by `jar` Gradle task. (_plain archive_)

_Reference: [Spring Boot (2.5.0) Gradle Plugin Reference - 4.3. Packaging Executable and Plain Archives](https://docs.spring.io/spring-boot/docs/2.5.0/gradle-plugin/reference/htmlsingle/#packaging-executable.and-plain-archives)_: 
> By default, when the bootJar or bootWar tasks are configured, the jar or war tasks are configured to use plain as the convention for their archive classifier. This ensures that bootJar and jar or bootWar and war have different output locations, allowing both the executable archive and the plain archive to be built at the same time.

<br/>

The main difference (in the context of the issue #2) is that the executable jar contains a `Main-Class` attribute in the `META-INF\MANIFEST.MF` file but the plain archive does not. So, when Heroku runs the ```java -Dserver.port=42236 $JAVA_OPTS -jar build/libs/*.jar``` command to start the Spring boot application, the plain archive is used, thus the start process fails.

The simplest solution is to disable `jar` task so that the archive file is not produced when the project is built and Heroku uses the executable jar. 
```groovy
// build.gradle

// ...
jar {
    enabled = false
}
```

### Additional Details:

Since the application's main class is automatically configured by the `bootJar` Gradle task, there is no need to explicitly configure a `mainClass` property or manifest attribuets in `bootJar` task in Gradle build script.

_Reference: [Spring Boot (2.5.0) Gradle Plugin Reference - 4.4.1. Configuring the Main Class](https://docs.spring.io/spring-boot/docs/2.5.0/gradle-plugin/reference/htmlsingle/#packaging-executable.configuring.main-class)_:
> By default, the executable archive’s main class will be configured automatically by looking for a class with a public static void main(String[]) method in directories on the task’s classpath.

So it is safe to remove below configuration from the `build.gradle` file:

```groovy
// build.gradle

// ...
bootJar {
    mainClass.set('com.mstar.paymentgateway.PaymentGatewayApplication')
    manifest {
        attributes 'Start-Class' : 'com.mstar.paymentgateway.PaymentGatewayApplication'
    }
}
```

fixes #2 